### PR TITLE
Stringify Date, Time and DateTime

### DIFF
--- a/lib/hanitizer/adapter/mysql.rb
+++ b/lib/hanitizer/adapter/mysql.rb
@@ -41,6 +41,10 @@ module Hanitizer
       case value
         when Fixnum
           value
+        when Time, DateTime
+          "'#{value.strftime('%Y-%m-%d %H:%M:%S')}'"
+        when Date
+          "'#{value.strftime('%Y-%m-%d')}'"
         when nil
           'NULL'
         else


### PR DESCRIPTION
MySQL tries to use a localized timestamp when inserting records back
into the DB which fails. (i.e. created_at)
